### PR TITLE
Use CC0-1.0 as valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-transform"
   ],
   "author": "Dan Abramov <dan.abramov@me.com> (http://github.com/gaearon)",
-  "license": "CC0",
+  "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/gaearon/react-transform-boilerplate/issues"
   },


### PR DESCRIPTION
To avoid this warning:
```
npm WARN package.json react-transform-boilerplate@1.0.0 license should be a valid SPDX license expression
```