### PR TITLE
Use the 1.1.0 release of Babel-Plugin-React-Transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,14 +4,16 @@
     "development": {
       "plugins": ["react-transform"],
       "extra": {
-        "react-transform": [{
-          "target": "react-transform-hmr",
-          "imports": ["react"],
-          "locals": ["module"]
-        }, {
-          "target": "react-transform-catch-errors",
-          "imports": ["react", "redbox-react"]
-        }]
+        "react-transform": {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }, {
+            "transform": "react-transform-catch-errors",
+            "imports": ["react", "redbox-react"]
+          }]
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-core": "^5.4.7",
     "babel-eslint": "^3.1.9",
     "babel-loader": "^5.1.2",
-    "babel-plugin-react-transform": "^1.0.1",
+    "babel-plugin-react-transform": "^1.1.0",
     "eslint": "^1.3.1",
     "eslint-plugin-react": "^2.3.0",
     "express": "^4.13.3",


### PR DESCRIPTION
To reflect the additions to the Babel-Plugin-React-Transform module, both the package.json and .babelrc have been updated in order to remove the warning message at startup for future apps.

![screen shot 2015-09-23 at 11 53 17 pm](https://cloud.githubusercontent.com/assets/7918530/10065088/9eca631e-624e-11e5-9b45-1f7f0fbdd6e9.png)

