### PR TITLE
Isolated hot reload babel configs to webpack config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,3 @@
 {
-  "stage": 0,
-  "env": {
-    "development": {
-      "plugins": ["react-transform"],
-      "extra": {
-        "react-transform": {
-          "transforms": [{
-            "transform": "react-transform-hmr",
-            "imports": ["react"],
-            "locals": ["module"]
-          }, {
-            "transform": "react-transform-catch-errors",
-            "imports": ["react", "redbox-react"]
-          }]
-        }
-      }
-    }
-  }
+  "stage": 0
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -19,8 +19,23 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.js$/,
-      loaders: ['babel'],
-      include: path.join(__dirname, 'src')
+      loader: 'babel',
+      include: path.join(__dirname, 'src'),
+      query: {
+        "plugins": ["react-transform"],
+        "extra": {
+          "react-transform": {
+            "transforms": [{
+              "transform": "react-transform-hmr",
+              "imports": ["react"],
+              "locals": ["module"]
+            }, {
+              "transform": "react-transform-catch-errors",
+              "imports": ["react", "redbox-react"]
+            }]
+          }
+        }
+      }
     }]
   }
 };


### PR DESCRIPTION
This prevents the babel configs from interfering with other tools that don't use hot reload.