### PR TITLE
Serve files from directory '/public' as static resources

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -13,6 +13,8 @@ app.use(require('webpack-dev-middleware')(compiler, {
 
 app.use(require('webpack-hot-middleware')(compiler));
 
+app.use('/public', express.static('public'));
+
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });


### PR DESCRIPTION
Resolves issue #22 
Any file that is within '/public' is served as static resource.
For any other url, index.html is served.