### PR TITLE
Make babel-load safer when use other environment like gulp | fixes #58

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -18,9 +18,25 @@ module.exports = {
   ],
   module: {
     loaders: [{
-      test: /\.js$/,
-      loaders: ['babel'],
-      include: path.join(__dirname, 'src')
+      test: /\.jsx?$/,
+      loader: 'babel',
+      include: path.join(__dirname, 'src'),
+      query: {
+        'stage': 0,
+        'plugins': ['react-transform'],
+        'extra': {
+          'react-transform': {
+            'transforms': [{
+              'transform': 'react-transform-hmr',
+              'imports': ['react'],
+              'locals': ['module']
+            }, {
+              'transform': 'react-transform-catch-errors',
+              'imports': ['react', 'redbox-react']
+            }]
+          }
+        }
+      }
     }]
   }
 };


### PR DESCRIPTION
If `devServer` called by gulp, `babel-loader` won't use the config in `.babelrc`, not sure why..

Maybe because gulp use external module `babel-core/register`

The solution is simple, just move the config which in `.babelrc` to `webpack.config.dev.js`

```js
loaders: [{
      test: /\.jsx?$/,
      loader: 'babel',
      query: {
        'stage': 0,
        'plugins': ['react-transform'],
        'extra': {
          'react-transform': {
            'transforms': [{
              'transform': 'react-transform-hmr',
              'imports': ['react'],
              'locals': ['module']
            }, {
              'transform': 'react-transform-catch-errors',
              'imports': ['react', 'redbox-react']
            }]
          }
        }
      }
    }]
  }
```

This change make `webpack-hot-middleware` stronger to avoid the other similar problems