### PR TITLE
Swap Slack for Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ React.render(<App />, document.getElementById('root'))
 
 ## Discussion
 
-You can discuss React Transform and related projects in **#react-transform** channel on [Reactiflux Slack](http://reactiflux.com).
+You can discuss React Transform and related projects in **#react-transform** channel on [Reactiflux Discord](http://reactiflux.com).
 
 ## License
 


### PR DESCRIPTION
Reactiflux Slack no longer exists. It's now on Discord.

We just need to create the **#react-transform** channel there.