### PR TITLE
Set "NODE_ENV" to "development" before running development server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "clean": "rimraf dist",
     "build:webpack": "NODE_ENV=production webpack --config webpack.config.prod.js",
     "build": "npm run clean && npm run build:webpack",
-    "start": "node devServer.js",
+    "start": "NODE_ENV=development node devServer.js",
     "lint": "eslint src"
   },
   "repository": {


### PR DESCRIPTION
Spent few hours figuring out why hot reloading is not working: "NODE_ENV" variable was set to "production" by default in my system (OS X 10.11.1, NodeJs 4.0.0). Setting it to "development" before development server start solved the problem.