### PR TITLE
changing devtool type

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,7 +2,7 @@ var path = require('path');
 var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'eval',
+  devtool: 'cheap-module-eval-source-map',
   entry: [
     'webpack-hot-middleware/client',
     './src/index'


### PR DESCRIPTION
This option for webapck devtool gives much better sourcemaps than 'eval' and still has good bundling/re-bundling performance