### PR TITLE
Added an EventSource polyfill 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "rimraf": "^2.4.3",
     "webpack": "^1.12.9",
     "webpack-dev-middleware": "^1.4.0",
-    "webpack-hot-middleware": "^2.6.0"
+    "webpack-hot-middleware": "^2.6.0",
+    "eventsource-polyfill": "^0.9.6"
   },
   "dependencies": {
     "react": "^0.14.3",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -4,6 +4,7 @@ var webpack = require('webpack');
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
+    'eventsource-polyfill',
     'webpack-hot-middleware/client',
     './src/index'
   ],


### PR DESCRIPTION
EventSource is required by browsers that don't support it yet (such as IE). It's used by [webpack-hot middleware](https://github.com/glenjamin/webpack-hot-middleware/issues/11).