### PR TITLE
Remove extra license text from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ You can discuss React Transform and related projects in **#react-transform** cha
 ## License
 
 CC0 (public domain)
-domain)


### PR DESCRIPTION
As I was reading through the docs, I noticed what appears to be a typo in the README under the license section. If I'm right, here's the fix!