### PR TITLE
Babel Loader test should match dev settings

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -26,7 +26,7 @@ module.exports = {
   ],
   module: {
     loaders: [{
-      test: /\.js$/,
+      test: /\.jsx?/,
       loaders: ['babel'],
       include: path.join(__dirname, 'src')
     }]


### PR DESCRIPTION
Dev loader test is `/\.jsx?/`, prod loader should use the same test or you won't transpile the same files.