### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No! This is experimental stuff. It’s not polished, it doesn’t work in all br
 
 #### Should I run this on the server / in tests / in production?
 
-No! This is only meant for client development environment. Make sure your `NODE_ENV` is neither `development` nor empty in these environments. Alternateively you can put the Babel configuration under a different `env` key and use your custom `NODE_ENV` or `BABEL_ENV` to turn these transforms on. Or you can [embed Babel configuration inside the Webpack config ](https://github.com/babel/babel-loader#options). No matter how you do it, **make sure you’re *only* running this transform in client-side development mode, and it is disabled on the server, in tests, and in production.**
+No! This is only meant for client development environment. Make sure your `NODE_ENV` is neither `development` nor empty in these environments. Alternatively you can put the Babel configuration under a different `env` key and use your custom `NODE_ENV` or `BABEL_ENV` to turn these transforms on. Or you can [embed Babel configuration inside the Webpack config ](https://github.com/babel/babel-loader#options). No matter how you do it, **make sure you’re *only* running this transform in client-side development mode, and it is disabled on the server, in tests, and in production.**
 
 #### I can’t serve images, use different HTML, add CSS, etc.
 
@@ -49,7 +49,7 @@ Again, this boilerplate is **not** intended to be production ready. The 404 is b
 
 #### What errors does it catch?
 
-`react-transform-catch-errors` catches **runtime errors inside `render()` method** of React componets it detects.
+`react-transform-catch-errors` catches **runtime errors inside `render()` method** of React components it detects.
 Webpack Hot Middleware catches **syntax errors anywhere in the module**.
 
 These are two different tools and you need to be aware of that.


### PR DESCRIPTION
Found some spelling mistakes -
`Alternateively` > `Alternatively`
`componets` > `components`