### PR TITLE
Update devServer.js

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -17,7 +17,7 @@ app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
-app.listen(3000, 'localhost', function(err) {
+app.listen(3000, function(err) {
   if (err) {
     console.log(err);
     return;


### PR DESCRIPTION
Remove localhost binding so allow express to listen universally on port 3000. This fixes #89. On Windows, when you have multiple network gateways (for my case, it was because I am on a corporate VPN), express gets quite particular about how it resolves. For some reason, the general request resolves fine, but the HMR requests don't. But when you allow express to be unbound from the hostname, it then allows HMR to work properly.