### PR TITLE
allow changing hostname and port of dev server

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -6,6 +6,9 @@ var config = require('./webpack.config.dev');
 var app = express();
 var compiler = webpack(config);
 
+var hostname = process.env.SERVER_HOSTNAME || 'localhost';
+var port = process.env.SERVER_PORT || 3000;
+
 app.use(require('webpack-dev-middleware')(compiler, {
   noInfo: true,
   publicPath: config.output.publicPath
@@ -17,11 +20,11 @@ app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
-app.listen(3000, 'localhost', function(err) {
+app.listen(port, hostname, function(err) {
   if (err) {
     console.log(err);
     return;
   }
 
-  console.log('Listening at http://localhost:3000');
+  console.log('Listening at http://' + hostname + ':' + port);
 });


### PR DESCRIPTION
This allows setting the hostname and port of the dev server to something other than localhost:3000 via:

```
# use different port
SERVER_PORT=1234 npm start

# allow other people to access the server
SERVER_HOSTNAME=0.0.0.0 npm start
```