### PR TITLE
POC: createElement patch + prototype methods patch

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,3 @@
 {
-  "presets": ["react", "es2015"],
-  "env": {
-    "development": {
-      "presets": ["react-hmre"]
-    }
-  }
+  "presets": ["react", "es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.13.3",
     "react-deep-force-update": "~2.0.1",
+    "react-router": "~2.0.1",
     "recompose": "~0.16.0",
     "rimraf": "^2.4.3",
     "webpack": "^1.12.9",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "eslint-plugin-react": "^3.11.3",
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.13.3",
+    "react-deep-force-update": "~2.0.1",
+    "recompose": "~0.16.0",
     "rimraf": "^2.4.3",
     "webpack": "^1.12.9",
     "webpack-dev-middleware": "^1.4.0",

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ class Counter extends Component {
 
 Counter.__id = 'Counter'
 
-class App extends Component {
+export class App extends Component {
   constructor(props) {
     super(props)
     this.blah = this.blah.bind(this)
@@ -44,7 +44,7 @@ class App extends Component {
     return (
       <div>
         <BogusText text='yay' />
-        <Counter increment={2} color={SUPER_NICE} />
+        <Counter increment={10} color={SUPER_NICE} />
         <Counter increment={5} color={SUPER_NICE} />
       </div>
     );
@@ -56,5 +56,3 @@ App.__id = 'App'
 const BogusText = ({text}) => <div>{text}</div>
 
 BogusText.__id = 'BogusText'
-
-export {App}

--- a/src/App.js
+++ b/src/App.js
@@ -27,13 +27,32 @@ class Counter extends Component {
   }
 }
 
-export class App extends Component {
+Counter.__id = 'Counter'
+
+class App extends Component {
+  constructor(props) {
+    super(props)
+    this.blah = this.blah.bind(this)
+  }
+
+  blah() {
+    console.log('yay')
+  }
+
   render() {
+    this.blah()
     return (
       <div>
-        <Counter increment={1} color={NICE} />
+        <BogusText text='yay' />
+        <Counter increment={10} color={SUPER_NICE} />
         <Counter increment={5} color={SUPER_NICE} />
       </div>
     );
   }
 }
+
+App.__id = 'App'
+
+const BogusText = ({text}) => <div>{text}hhhh</div>
+
+export {App}

--- a/src/App.js
+++ b/src/App.js
@@ -36,15 +36,17 @@ export class App extends Component {
   }
 
   blah() {
-    console.log('yay')
+    console.log('double yay')
   }
 
   render() {
     this.blah()
     return (
       <div>
-        <BogusText text='yay' />
-        <Counter increment={10} color={SUPER_NICE} />
+        <BogusContainer>
+          <Counter increment={50} color={NICE} />
+        </BogusContainer>
+        <Counter increment={2} color={SUPER_NICE} />
         <Counter increment={5} color={SUPER_NICE} />
       </div>
     );
@@ -53,6 +55,6 @@ export class App extends Component {
 
 App.__id = 'App'
 
-const BogusText = ({text}) => <div>{text}</div>
+const BogusContainer = ({children}) => <div>bogus: {children}</div>
 
-BogusText.__id = 'BogusText'
+BogusContainer.__id = 'BogusText'

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { NICE, SUPER_NICE } from './colors';
+import OtherCounter from './hoc'
 
 class Counter extends Component {
   constructor(props) {
@@ -10,7 +11,7 @@ class Counter extends Component {
 
   tick() {
     this.setState({
-      counter: this.state.counter + this.props.increment
+      counter: this.state.counter - this.props.increment
     });
   }
 
@@ -44,10 +45,11 @@ export class App extends Component {
     return (
       <div>
         <BogusContainer>
-          <Counter increment={50} color={NICE} />
+          <Counter increment={10} color={NICE} />
         </BogusContainer>
         <Counter increment={2} color={SUPER_NICE} />
         <Counter increment={5} color={SUPER_NICE} />
+        <OtherCounter increment={5} color={NICE} />
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ class Counter extends Component {
 
   tick() {
     this.setState({
-      counter: this.state.counter - this.props.increment
+      counter: this.state.counter + this.props.increment
     });
   }
 
@@ -37,7 +37,7 @@ export class App extends Component {
   }
 
   blah() {
-    console.log('double yay')
+    console.log('App.prototype.render was called')
   }
 
   render() {
@@ -47,7 +47,7 @@ export class App extends Component {
         <BogusContainer>
           <Counter increment={10} color={NICE} />
         </BogusContainer>
-        <Counter increment={2} color={SUPER_NICE} />
+        <Counter increment={100} color={SUPER_NICE} />
         <Counter increment={5} color={SUPER_NICE} />
         <OtherCounter increment={5} color={NICE} />
       </div>
@@ -60,3 +60,7 @@ App.__id = 'App'
 const BogusContainer = ({children}) => <div>bogus: {children}</div>
 
 BogusContainer.__id = 'BogusText'
+
+export const AppSFC = () => <App />
+
+AppSFC.__id = 'AppSFC'

--- a/src/App.js
+++ b/src/App.js
@@ -44,7 +44,7 @@ class App extends Component {
     return (
       <div>
         <BogusText text='yay' />
-        <Counter increment={10} color={SUPER_NICE} />
+        <Counter increment={2} color={SUPER_NICE} />
         <Counter increment={5} color={SUPER_NICE} />
       </div>
     );
@@ -53,6 +53,8 @@ class App extends Component {
 
 App.__id = 'App'
 
-const BogusText = ({text}) => <div>{text}hhhh</div>
+const BogusText = ({text}) => <div>{text}</div>
+
+BogusText.__id = 'BogusText'
 
 export {App}

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import { pure } from 'recompose'
+
+class OtherCounter extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { counter: 0 };
+    this.interval = setInterval(() => this.tick(), 1000);
+  }
+
+  tick() {
+    this.setState({
+      counter: this.state.counter + this.props.increment
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    return (
+      <h1 style={{ color: this.props.color }}>
+        OtherCounter -- ({this.props.increment}): {this.state.counter} --
+      </h1>
+    );
+  }
+}
+
+OtherCounter.defaultProps = {
+  increment: 10,
+}
+
+export default pure(OtherCounter)

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,84 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { App } from './App';
+import forceUpdate from 'react-deep-force-update'
 
-render(<App />, document.getElementById('root'));
+const Components = new Map()
+
+const patchRender = (Component) => {
+  const id = Component.__id
+  return function(...args) {
+    return Components.get(id).apply(this, args)
+  }
+}
+
+const patchPrototype = (Component) => {
+  for (const method of Object.getOwnPropertyNames(Component.prototype)) {
+    if (typeof Component.prototype[method] == 'function') {
+      const bind = (ctx, ...boundArgs) => {
+        return (...args) => {
+          return Component.prototype[method].call(ctx, ...boundArgs, ...args)
+        }
+      }
+      Component.prototype[method].bind = bind
+    }
+  }
+}
+
+const patchComponent = (Component) => {
+  console.log('first', Component.__id)
+
+  Components.set(Component.__id, Component)
+
+  if (React.Component.prototype.isPrototypeOf(Component.prototype)) {
+    patchPrototype(Component)
+  } else {
+    Component = patchRender(Component)
+  }
+
+  return Component
+}
+
+const updateComponent = (NextComponent) => {
+  console.log('update', NextComponent.__id)
+
+  if (React.Component.prototype.isPrototypeOf(NextComponent.prototype)) {
+    patchPrototype(NextComponent)
+    const PrevComponent = Components.get(NextComponent.__id)
+    for (const method of Object.getOwnPropertyNames(NextComponent.prototype)) {
+      PrevComponent.prototype[method] = NextComponent.prototype[method]
+    }
+
+    return PrevComponent
+  } else {
+    Components.set(NextComponent.__id, NextComponent)
+    return NextComponent
+  }
+}
+
+const realCreateElement = React.createElement
+
+React.createElement = function createElement(type, ...args) {
+  if (typeof type == 'function') {
+    if (Components.has(type.__id)) {
+      type = updateComponent(type)
+    } else {
+      type = patchComponent(type)
+    }
+  }
+
+  return realCreateElement(type, ...args)
+}
+
+const tree = render(
+  <App />,
+  document.getElementById('root')
+);
+
+if (module.hot) {
+  module.hot.accept('./App', () => {
+    const NextApp = require('./App').App
+    updateComponent(NextApp)
+    forceUpdate(tree)
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -42,9 +42,15 @@ const patchComponent = (Component) => {
 const updateComponent = (NextComponent) => {
   console.log('update', NextComponent.__id)
 
+  const PrevComponent = Components.get(NextComponent.__id)
+  if (!PrevComponent) {
+    // this isn't registered as a react component, nothing to do
+    return
+  }
+
   if (React.Component.prototype.isPrototypeOf(NextComponent.prototype)) {
     patchPrototype(NextComponent)
-    const PrevComponent = Components.get(NextComponent.__id)
+
     for (const method of Object.getOwnPropertyNames(NextComponent.prototype)) {
       PrevComponent.prototype[method] = NextComponent.prototype[method]
     }
@@ -52,6 +58,7 @@ const updateComponent = (NextComponent) => {
     return PrevComponent
   } else {
     Components.set(NextComponent.__id, NextComponent)
+
     return NextComponent
   }
 }
@@ -70,10 +77,7 @@ React.createElement = function createElement(type, ...args) {
   return realCreateElement(type, ...args)
 }
 
-const tree = render(
-  <App />,
-  document.getElementById('root')
-);
+const tree = render(<App />, document.getElementById('root'));
 
 if (module.hot) {
   module.hot.accept('./App', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ const updateComponent = (NextComponent) => {
     for (const method of Object.getOwnPropertyNames(NextComponent.prototype)) {
       PrevComponent.prototype[method] = NextComponent.prototype[method]
     }
+    // TODO: remove methods that do not exist in NextComponent.prototype
 
     return PrevComponent
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import { App } from './App';
 import forceUpdate from 'react-deep-force-update'
 
-const id = (Component) => Component.__id || Component.displayName || Component.name
+const id = (Component) => Component.__id
 
 const Components = new Map()
 const SFCWrappers = new Map()
@@ -94,7 +94,7 @@ const updateComponent = (NextComponent) => {
 const realCreateElement = React.createElement
 
 React.createElement = function createElement(type, ...args) {
-  if (typeof type == 'function') {
+  if (typeof type == 'function' && id(type)) {
     if (Components.has(id(type))) {
       type = updateComponent(type)
     } else if (!Updated.has(type)) {

--- a/src/index.js
+++ b/src/index.js
@@ -102,15 +102,22 @@ React.createElement = function createElement(type, ...args) {
     }
   }
 
-  return realCreateElement(type, ...args)
+  return realCreateElement.call(this, type, ...args)
 }
 
 const tree = render(<App />, document.getElementById('root'));
 
+// import {Router, Route, browserHistory} from 'react-router'
+// const tree = render(
+//   <Router history={browserHistory} createElement={React.createElement}>
+//     <Route path='/' component={App} />
+//   </Router>,
+//   document.getElementById('root')
+// )
+
 if (module.hot) {
   module.hot.accept('./App', () => {
-    const NextApp = require('./App').App
-    updateComponent(NextApp)
+    updateComponent(require('./App').App)
     forceUpdate(tree)
   })
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -3,7 +3,7 @@ var webpack = require('webpack');
 
 module.exports = {
   // or devtool: 'eval' to debug issues with compiled output:
-  devtool: 'cheap-module-eval-source-map',
+  devtool: '#cheap-module-eval-source-map',
   entry: [
     // necessary for hot reloading with IE:
     'eventsource-polyfill',


### PR DESCRIPTION
open questions that i can think of: 
- still needs some way of assigning unique IDs to react components (for the POC i did that manually)
- ~~still have to test whether this works for components wrapped in a HOC~~ it appears to work
- patching `React.createElement` doesn't play well with code like this https://github.com/reactjs/react-router/blob/master/modules/RouterContext.js#L29 (unless there's some foolproof way of ensuring the patch happens before any line like that is ran) Making it work with react router currently requires providing the createElement prop like this `<Router history={browserHistory} createElement={React.createElement}>` (and that still doesn't work if route components are not classes, which I think is related to the issue below)
- for a tree composed only of SFCs I have no idea how to `forceUpdate` it after hot reloading, since I can't get a ref to it

notes:
- I ignored components components created with `React.createClass()` but they shouldn't be any different
- I was surprised by this but it appears to work on components that are not module exports, not sure it works always though because I wasn't really expecting this (basically it works because even though you might not have changed the render method of the exported component, it gets replaced and the replacement holds references to the new non-exported components, which themselves get replaced in te call to `React.createElement()`
